### PR TITLE
use "tablet" input type

### DIFF
--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -76,8 +76,8 @@
     <console type='pty'>
       <target type='serial' port='0'/>
     </console>
-    <input type="tablet" bus="usb">
-      <address type="usb" bus="0" port="1"/>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
     </input>
     <input type='keyboard' bus='usb'>
       <address type='usb' bus='0' port='2'/>

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -76,8 +76,8 @@
     <console type='pty'>
       <target type='serial' port='0'/>
     </console>
-    <input type='mouse' bus='usb'>
-      <address type='usb' bus='0' port='1'/>
+    <input type="tablet" bus="usb">
+      <address type="usb" bus="0" port="1"/>
     </input>
     <input type='keyboard' bus='usb'>
       <address type='usb' bus='0' port='2'/>


### PR DESCRIPTION
Input type "mouse" gets stuck and is unusable. tablet works better.

Thanks for this project, it was easy to get up and running with virt-manager.